### PR TITLE
Fix ITextIndex under Python 3.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == '__main__':

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build/
 .coverage
 coverage.xml
 nosetests.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,25 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
-  - pypy
-  - pypy3
-install:
-  - pip install tox-travis
+  - 3.6
+  - pypy-5.4.1
 script:
-  - tox
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
+
+cache: pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,12 @@ Changes
 4.2.0 (unreleased)
 ------------------
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
 - Drop support for Python 2.6.
+
+- Fix the text index throwing a ``WrongType`` error on import in
+  Python 3. See `issue 5 <https://github.com/zopefoundation/zope.catalog/issues/5>`_.
 
 4.1.0 (2015-06-02)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,16 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
-setup(name = 'zope.catalog',
+tests_require = [
+    'zope.site',
+    'zope.testing',
+    'zope.testrunner',
+]
+
+setup(name='zope.catalog',
       version='4.2.0.dev0',
       author='Zope Corporation and Contributors',
       author_email='zope-dev@zope.org',
@@ -34,8 +41,8 @@ setup(name = 'zope.catalog',
           + '\n\n' +
           read('CHANGES.rst')
           ),
-      keywords = "zope3 catalog index",
-      classifiers = [
+      keywords="zope3 catalog index",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -47,6 +54,7 @@ setup(name = 'zope.catalog',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
@@ -56,13 +64,12 @@ setup(name = 'zope.catalog',
       url='http://pypi.python.org/pypi/zope.catalog',
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope'],
-      extras_require = dict(
-          test=['zope.testing',
-                'zope.site',
-                ]),
-      install_requires = [
+      extras_require={
+          'test': tests_require,
+      },
+      install_requires=[
           'setuptools',
           'persistent',
           'BTrees',
@@ -75,9 +82,9 @@ setup(name = 'zope.catalog',
           'zope.lifecycleevent',
           'zope.location',
           'zope.schema',
-          ],
-      tests_require = ['zope.testing', 'zope.site'],
-      test_suite = 'zope.catalog.tests.test_suite',
-      include_package_data = True,
-      zip_safe = False,
-      )
+      ],
+      tests_require=tests_require,
+      test_suite='zope.catalog.tests.test_suite',
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/catalog/text.py
+++ b/src/zope/catalog/text.py
@@ -35,7 +35,7 @@ class ITextIndex(zope.catalog.interfaces.IAttributeIndex,
         default=zope.index.text.interfaces.ISearchableText,
         )
 
-    field_name = zope.schema.BytesLine(
+    field_name = zope.schema.NativeStringLine(
         title=_(u"Field Name"),
         description=_(u"Name of the field to index"),
         default="getSearchableText"

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,18 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage,docs
+    py27,py33,py34,py35,py36,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
 deps =
-    ZODB
-    BTrees
-    zope.annotation
-    zope.intid
-    zope.component
-    zope.container
-    zope.index
-    zope.interface
-    zope.lifecycleevent
-    zope.location
-    zope.schema
-    zope.site
-    zope.testing
+    .[test]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
-commands = 
+commands =
     nosetests --with-xunit --with-xcoverage
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Fixes #5

- Add support for Python 3.6
- Use pip caching on Travis and enable coveralls.
- 100% test coverage