### PR TITLE
IAttributeIndex uses NativeStringLine for field_name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changes
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix the definition of ``IAttributeIndex`` to specify a
+  ``NativeStringLine`` instead of a ``BytesLine``. Bytes cannot be
+  used with ``getattr`` on Python 3.
+  See `issue 7 <https://github.com/zopefoundation/zope.catalog/issues/7>`_.
 
 
 4.2.0 (2017-05-05)

--- a/src/zope/catalog/interfaces.py
+++ b/src/zope/catalog/interfaces.py
@@ -82,7 +82,7 @@ class IAttributeIndex(zope.interface.Interface):
         required=False,
         )
 
-    field_name = zope.schema.BytesLine(
+    field_name = zope.schema.NativeStringLine(
         title=_(u"Field Name"),
         description=_(u"Name of the field to index"),
         )


### PR DESCRIPTION
Fixes #7.

Also fixes issues in zopefoundation/zc.catalog#3