### PR TITLE
Fix broken doctests and run doctests on all versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ notifications:
 install:
   - pip install -U pip setuptools
   - pip install -U coveralls coverage
-  - pip install -U -e ".[test]"
+  - pip install -U -e ".[test,docs]"
 
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy-5.4.1
+  - pypy
+  - pypy3
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
-
+  - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 after_success:
   - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,15 @@
-Changes
-=======
+=========
+ Changes
+=========
 
-4.2.2 (unreleased)
-------------------
+4.3.0 (unreleased)
+==================
 
-- Nothing changed yet.
+- Drop support for Python 3.3.
 
 
 4.2.1 (2017-05-09)
-------------------
+==================
 
 - Fix the definition of ``IAttributeIndex`` to specify a
   ``NativeStringLine`` instead of a ``BytesLine``. Bytes cannot be
@@ -17,7 +18,7 @@ Changes
 
 
 4.2.0 (2017-05-05)
-------------------
+==================
 
 - Add support for Python 3.5 and 3.6.
 
@@ -27,7 +28,7 @@ Changes
   Python 3. See `issue 5 <https://github.com/zopefoundation/zope.catalog/issues/5>`_.
 
 4.1.0 (2015-06-02)
-------------------
+==================
 
 - Replace use of long-deprecated ``zope.testing.doctest`` with stdlib's
   ``doctest``.
@@ -39,12 +40,12 @@ Changes
   and running doctest snippets under ``tox``.
 
 4.0.0 (2014-12-24)
-------------------
+==================
 
 - Add support for Python 3.4.
 
 4.0.0a1 (2013-02-25)
---------------------
+====================
 
 - Add support for Python 3.3.
 
@@ -54,17 +55,17 @@ Changes
 - Drop support for Python 2.4 and 2.5.
 
 3.8.2 (2011-11-29)
-------------------
+==================
 
 - Conform to repository policy.
 
 3.8.1 (2009-12-27)
-------------------
+==================
 
 - Remov ``zope.app.testing`` dependency.
 
 3.8.0 (2009-02-01)
-------------------
+==================
 
 - Move core functionality from ``zope.app.catalog`` to this package.
   The ``zope.app.catalog`` package now only contains ZMI-related browser

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,20 @@
-``zope.catalog``
-================
+==============
+ zope.catalog
+==============
 
-.. image:: http://badge.kloud51.com/pypi/v/zope.catalog.svg
-    :target: https://pypi.python.org/pypi/zope.catalog/
-    :alt: Latest Version
+.. image:: https://img.shields.io/pypi/v/zope.catalog.svg
+        :target: https://pypi.python.org/pypi/zope.catalog/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.catalog.svg
+        :target: https://pypi.org/project/zope.catalog/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.catalog.svg?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.catalog
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.catalog/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.catalog?branch=master
 
 .. image:: https://readthedocs.org/projects/zopecatalog/badge/?version=latest
         :target: http://zopecatalog.readthedocs.org/en/latest/

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -47,7 +47,7 @@ We also need an intid util and a keyreference adapter.
     ...     def __init__(self, name):
     ...         self.__name__ = name
     ...     def __repr__(self):
-    ...         return '<Dummy %r>' % self.__name__
+    ...         return '<Dummy %r>' % str(self.__name__)
 
 We have a subscriber to IIntidAddedEvent.
 
@@ -64,7 +64,7 @@ Now we have indexed the object.
 .. doctest::
 
     >>> cat.indexed.pop()
-    (..., <Dummy u'one'>)
+    (..., <Dummy 'one'>)
 
 When an object is modified an objectmodified event should be fired by
 the application. Here is the handler for such an event.
@@ -76,7 +76,7 @@ the application. Here is the handler for such an event.
     >>> len(cat.indexed)
     1
     >>> cat.indexed.pop()
-    (..., <Dummy u'one'>)
+    (..., <Dummy 'one'>)
 
 Preventing automatic indexing
 -----------------------------

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -1,18 +1,19 @@
-Using :mod:`zope.catalog`
-=========================
+===========================
+ Using :mod:`zope.catalog`
+===========================
 
 .. testsetup::
 
-   from zope.catalog.tests import placelessSetUp
-   placelessSetUp()
+   from zope.testing.cleanup import setUp
+   setUp()
 
 .. testcleanup::
 
-   from zope.catalog.tests import placelessTearDown
-   placelessTearDown()
+   from zope.testing.cleanup import tearDown
+   tearDown()
 
 Basic Usage
------------
+===========
 
 Let's look at an example:
 
@@ -221,8 +222,8 @@ access its indexes directly, since the catalog is a mapping:
 
 .. doctest::
 
-    >>> [(name, cat[name].field_name) for name in cat]
-    [(u'age', 'age'), (u'color', 'color'), (u'size', 'sz')]
+    >>> [(str(name), cat[name].field_name) for name in cat]
+    [('age', 'age'), ('color', 'color'), ('size', 'sz')]
 
 Catalogs work with int-id utilities, which are responsible for
 maintaining id <-> object mappings.  To see how this works, we'll
@@ -421,7 +422,7 @@ The score increased because we used an additional index.  If an index
 doesn't provide scores, scores of 1.0 are assumed.
 
 Additional Topics
------------------
+=================
 
 .. toctree::
    :maxdepth: 2

--- a/rtd.txt
+++ b/rtd.txt
@@ -1,14 +1,1 @@
-BTrees
-repoze.sphinx.autointerface
-ZODB
-zope.annotation
-zope.intid
-zope.component
-zope.container
-zope.index
-zope.interface
-zope.lifecycleevent
-zope.location
-zope.schema
-zope.site
-zope.testing
+.[docs]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='zope.catalog',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
+      ),
       keywords="zope3 catalog index",
       classifiers=[
           'Development Status :: 5 - Production/Stable',
@@ -51,7 +51,6 @@ setup(name='zope.catalog',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
@@ -60,14 +59,19 @@ setup(name='zope.catalog',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.catalog',
+          'Framework :: Zope3',
+      ],
+      url='https://github.com/zopefoundation/zope.catalog',
       license='ZPL 2.1',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       namespace_packages=['zope'],
       extras_require={
           'test': tests_require,
+          'docs': [
+              'Sphinx',
+              'repoze.sphinx.autointerface',
+          ]
       },
       install_requires=[
           'setuptools',

--- a/src/zope/catalog/tests.py
+++ b/src/zope/catalog/tests.py
@@ -704,28 +704,18 @@ class TestAttributeIndex(cleanup.CleanUp,
         # native string
         idx = AttributeIndex(field_name='foo')
         verifyObject(IAttributeIndex, idx)
-        if bytes is str:
-            # Python 2
-            idx = AttributeIndex(field_name=b'foo')
-            verifyObject(IAttributeIndex, idx)
-            self.assertEqual(getValidationErrors(IAttributeIndex, idx),
-                             [])
+        good_name = b'foo' if bytes is str else u'foo'
+        bad_name = u'foo' if bytes is str else b'foo'
 
-            idx = AttributeIndex(field_name=u'foo')
-            verifyObject(IAttributeIndex, idx)
-            self.assertEqual(getValidationErrors(IAttributeIndex, idx)[0][0],
-                             'field_name')
+        idx = AttributeIndex(field_name=good_name)
+        verifyObject(IAttributeIndex, idx)
+        self.assertEqual(getValidationErrors(IAttributeIndex, idx),
+                         [])
 
-        else:
-            idx = AttributeIndex(field_name=u'foo')
-            verifyObject(IAttributeIndex, idx)
-            self.assertEqual(getValidationErrors(IAttributeIndex, idx),
-                             [])
-
-            idx = AttributeIndex(field_name=b'foo')
-            verifyObject(IAttributeIndex, idx)
-            self.assertEqual(getValidationErrors(IAttributeIndex, idx)[0][0],
-                             'field_name')
+        idx = AttributeIndex(field_name=bad_name)
+        verifyObject(IAttributeIndex, idx)
+        self.assertEqual(getValidationErrors(IAttributeIndex, idx)[0][0],
+                         'field_name')
 
 
 class TestTextIndex(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,25 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,py36,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =
     zope-testrunner --test-path=src []
+    sphinx-build -b doctest -d {envdir}/doctrees docs {envdir}/doctest
 deps =
-    .[test]
+    .[test,docs]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src []
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
-    nose
     coverage
-    nosexcover
 
 [testenv:docs]
 basepython =
@@ -26,7 +27,3 @@ basepython =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    {[testenv]deps}
-    Sphinx
-    repoze.sphinx.autointerface


### PR DESCRIPTION
``zope.catalog.tests.placelessSetUp`` was removed so doctests didn't run anymore.

Also some minor project updates:

- Remove claim to support Python 3.3. This hasn't been tested on Travis for some time. Also remove 3.3 from tox.ini.
- Modern coverage tox environment.
   - Simplify one test case to get 100% coverage no matter what version of Python runs. And also to not repeat ourself.
- Run doctests on travis.
- Fix broken badge and add version badges.
- Use modern PyPy on Travis.
- DRY in 'rtd.txt'. Incidentally, this probably fixes #9