### PR TITLE
Fix deprecated use of zope.site.hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Drop support for Python 3.3.
 
+- Replace deprecated usage of ``zope.site.hooks`` with
+  ``zope.component.hooks``.
+
 
 4.2.1 (2017-05-09)
 ==================

--- a/src/zope/catalog/tests.py
+++ b/src/zope/catalog/tests.py
@@ -30,7 +30,7 @@ from zope.component import provideAdapter
 from zope.component import provideHandler
 from zope.component import testing, eventtesting
 from zope.component.interfaces import ISite, IComponentLookup
-from zope.site.hooks import setSite, setHooks, resetHooks
+from zope.component.hooks import setSite, setHooks, resetHooks
 from zope.site.folder import Folder, rootFolder
 from zope.site.site import SiteManagerAdapter, LocalSiteManager
 from zope.traversing import api


### PR DESCRIPTION
/zope/catalog/tests.py:33: DeprecationWarning: zope.site.hooks has moved to zope.component.hooks. Import of zope.site.hooks will become unsupported in Version 5.0