### PR TITLE
Replace deprecated test usage of zope.component.interfaces.IComponentLookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 - Replace deprecated usage of ``zope.site.hooks`` with
   ``zope.component.hooks``.
 
+- Replace deprecated test usage of
+  ``zope.component.interfaces.IComponentLookup`` with the proper
+  import from ``zope.interface``. This only impacted testing this
+  package.
+
 
 4.2.1 (2017-05-09)
 ==================

--- a/src/zope/catalog/tests.py
+++ b/src/zope/catalog/tests.py
@@ -21,6 +21,7 @@ import re
 import unittest
 
 from zope.interface import implementer, Interface, alsoProvides
+from zope.interface.interfaces import IComponentLookup
 from zope.interface.verify import verifyObject
 from BTrees.IFBTree import IFSet
 from zope.intid.interfaces import IIntIds
@@ -29,7 +30,7 @@ from zope.component import provideUtility
 from zope.component import provideAdapter
 from zope.component import provideHandler
 from zope.component import testing, eventtesting
-from zope.component.interfaces import ISite, IComponentLookup
+from zope.component.interfaces import ISite
 from zope.component.hooks import setSite, setHooks, resetHooks
 from zope.site.folder import Folder, rootFolder
 from zope.site.site import SiteManagerAdapter, LocalSiteManager


### PR DESCRIPTION
with proper import from zope.interface.

This only affected testing this package.